### PR TITLE
Use `mamba` in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v2.2.0
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          channel-priority: strict
           environment-file: binder/environment.yml
           activate-environment: dask-tutorial-advanced
           auto-activate-base: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
-on: [push]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   binder:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,15 +2,16 @@ name: dask-tutorial-advanced
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
-  - dask=2023.5.1
+  - python=3.11
+  - dask=2023.6.1
   - python-graphviz
   - imageio
   - scipy
   - matplotlib
   - pip
   - pyarrow
+  - s3fs
   # JupyterLab + extensions
-  - jupyterlab>=3
+  - jupyterlab>=3,<4
   - dask-labextension
   - ipywidgets


### PR DESCRIPTION
It looks like our conda solve CI job is failing on `main` for some reason. For example, eee [this CI build](https://github.com/dask-contrib/dask-tutorial-advanced/actions/runs/5448554837/jobs/9911880184?pr=5) over in https://github.com/dask-contrib/dask-tutorial-advanced/pull/5. 

It looks like switch to using `mamba` in CI instead of `conda` resolves this issue. It's probably worth switch anyways to speed CI builds up. 